### PR TITLE
Add CLI args, update playlist name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1033,8 @@ name = "music-chat-tracker"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "clap",
+ "dotenv",
  "env_logger",
  "log",
  "regex",
@@ -1826,6 +1855,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ tempfile = "3.10.1"
 rspotify = { version = "0.12.0", features = ["env-file", "cli"] }
 tokio = { version = "1", features = ["full"] }
 rusqlite = { version = "0.31.0", features = ["bundled", "blob"] }
+clap = { version = "4.5.8", features = ["cargo"] }
+dotenv = "0.15.0"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ You will need to save these values as environment variables in the .env file:
 RSPOTIFY_CLIENT_ID="your-client-id"
 RSPOTIFY_CLIENT_SECRET="your-client-secret"
 RSPOTIFY_REDIRECT_URI="your-redirect-uri"
+CHAT_DB_PATH = "~/Library/Messages/chat.db"
+CHAT_DISPLAY_NAME = "Name of The Chat"
+PLAYLIST_ID = "yourplaylistid1234"
+DEFAULT_FILTER_START_DATE = "YYYY-MM-DD"
 ```
 
 ### Full Disk Access
@@ -50,6 +54,18 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 - Test it: `cargo test`
 - Run it: `cargo run`
 - Run it with logs: `RUST_LOG=info cargo run`
+#### Arguments
+You can use the following command line arguments to override the values in your .env:
+
+`--playlist-id`, `-p` - The ID of the playlist.
+
+`--chat-display-name`, `-c` - The display name for the chat.
+
+`--filter-start-date`, `-f` - The start date for filtering.
+
+`--update-interval-s`, `-i` - The update interval in seconds. Defaults to `60*60*6`, 6 hours.
+
+`--chat-db-path`, `-d` - The path to the chat database.
 
 ## Notes
 ### TODO:

--- a/mock.env
+++ b/mock.env
@@ -1,3 +1,7 @@
 RSPOTIFY_CLIENT_ID="clientid"
 RSPOTIFY_CLIENT_SECRET="clientsecret"
 RSPOTIFY_REDIRECT_URI="uri"
+CHAT_DB_PATH = "~/Library/Messages/chat.db"
+CHAT_DISPLAY_NAME = "Name of The Chat"
+PLAYLIST_ID = "yourplaylistid1234"
+DEFAULT_FILTER_START_DATE = "YYYY-MM-DD"

--- a/src/playlist_handler.rs
+++ b/src/playlist_handler.rs
@@ -98,7 +98,11 @@ async fn add_tracks_to_playlist_if_not_exists(
 }
 
 #[tokio::main]
-pub async fn add_tracks_to_playlist(playlist_id_str: &str, track_ids_to_add: Vec<String>) {
+pub async fn add_tracks_to_playlist(
+    playlist_id_str: &str,
+    track_ids_to_add: Vec<String>,
+    chat_display_name: &str,
+) {
     let spotify: AuthCodeSpotify = build_rspotify_client().await;
 
     let playlist_id: PlaylistId = PlaylistId::from_id(playlist_id_str).unwrap();
@@ -115,9 +119,17 @@ pub async fn add_tracks_to_playlist(playlist_id_str: &str, track_ids_to_add: Vec
     .await;
 
     let current_date = Local::now().format("%Y-%m-%d").to_string();
-    let description = format!("All songs sent in the Music (A Little Spam) group chat since I was added. Last updated on {}.", current_date);
-    let x = spotify
-        .playlist_change_detail(playlist_id, None, None, Some(description.as_str()), None)
+    let updated_playlist_name =
+        format!("{} Archive - (Updated {})", chat_display_name, current_date);
+    let updated_playlist_description = format!("All songs sent in the Music (A Little Spam) group chat since I was added. Last updated on {}.", current_date);
+    let _ = spotify
+        .playlist_change_detail(
+            playlist_id,
+            Some(updated_playlist_name.as_str()),
+            None,
+            Some(updated_playlist_description.as_str()),
+            None,
+        )
         .await;
 
     info!(


### PR DESCRIPTION
`--playlist-id`, `-p` - The ID of the playlist.
`--chat-display-name`, `-c` - The display name for the chat.
`--filter-start-date`, `-f` - The start date for filtering.
`--update-interval-s`, `-i` - The update interval in seconds. Defaults to `60*60*6`, 6 hours.
`--chat-db-path`, `-d` - The path to the chat database.

Playlist name is updated to "{chat_display_name} Archive - (Updated {current_date})"